### PR TITLE
Fixed stack corruption on some phones...

### DIFF
--- a/ifaddrs.c
+++ b/ifaddrs.c
@@ -576,11 +576,17 @@ int getifaddrs(struct ifaddrs **ifap)
     }
     
     unsigned l_numLinks = countLinks(l_socket, l_linkResults) + countLinks(l_socket, l_addrResults);
-    struct ifaddrs *l_links[l_numLinks];
-    memset(l_links, 0, l_numLinks * sizeof(struct ifaddrs *));
+    size_t needed_size = l_numLinks * sizeof(struct ifaddrs *);
+    struct ifaddrs ** l_links = (struct ifaddrs **) malloc (needed_size);
+    if (l_links)
+    {
+        memset(l_links, 0, l_numLinks * sizeof(struct ifaddrs *));
     
-    interpret(l_socket, l_linkResults, l_links, ifap);
-    interpret(l_socket, l_addrResults, l_links, ifap);
+        interpret(l_socket, l_linkResults, l_links, ifap);
+        interpret(l_socket, l_addrResults, l_links, ifap);
+        
+        free (l_links);
+    }
 
     freeResultList(l_linkResults);
     freeResultList(l_addrResults);


### PR DESCRIPTION
the dynamically allocated array on the stack can crash some phones, moved that to a block allocated in main memory.